### PR TITLE
:recycle: refactor: enable default tenant on tenant context

### DIFF
--- a/src/middlewares/context.ts
+++ b/src/middlewares/context.ts
@@ -20,8 +20,10 @@ export const setCorrelationId = (req: Request, res: Response, next: NextFunction
     next();
 };
 
-export const setTenantId = (req: Request, res: Response, next: NextFunction) => {
-    const tenantId = req.headers['x-tenant-id'] as string;
-    setHookTenantId(tenantId);
-    next();
+export const setTenantId = (defaultTenantId: string) => {
+    return (req: Request, res: Response, next: NextFunction) => {
+        const tenantId = req.headers['x-tenant-id'] as string | undefined;
+        setHookTenantId(tenantId ?? defaultTenantId);
+        next();
+    };
 };

--- a/tests/middlewares/context.spec.ts
+++ b/tests/middlewares/context.spec.ts
@@ -1,0 +1,119 @@
+import type { Request, Response, NextFunction } from 'express';
+import type { Mock } from 'vitest';
+import { setContext, setCorrelationId, setTenantId } from '../../src/middlewares/context';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import * as hooks from '../../src/core/hooks';
+import { Uuid } from '../../src/core/uuid';
+
+// Mock dependencies
+vi.mock('../../src/core/hooks');
+vi.mock('../../src/core/uuid');
+
+describe('Context Middleware', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let mockNext: NextFunction;
+
+  beforeEach(() => {
+    mockRequest = {
+      headers: {},
+      body: {}
+    };
+    mockResponse = {};
+    mockNext = vi.fn();
+    vi.clearAllMocks();
+  });
+
+  describe('set context', () => {
+    it('should call setHookContext and next', () => {
+      setContext(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(hooks.setHookContext).toHaveBeenCalled();
+    });
+  });
+
+  describe('set correlation id', () => {
+    it('should use correlation ID from header', () => {
+      const testCorrelationId = 'test-correlation-id';
+      mockRequest.headers = {
+        'x-correlation-id': testCorrelationId
+      };
+
+      setCorrelationId(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(hooks.setHookCorrelationId).toHaveBeenCalledWith(testCorrelationId);
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('should use correlation ID from message attributes', () => {
+      const testCorrelationId = 'test-correlation-id';
+      mockRequest.body = {
+        message: {
+          attributes: {
+            correlationId: testCorrelationId
+          }
+        }
+      };
+
+      setCorrelationId(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(hooks.setHookCorrelationId).toHaveBeenCalledWith(testCorrelationId);
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('should generate new correlation ID if none provided', () => {
+      const mockUuid = 'generated-uuid';
+      (Uuid.random as Mock).mockReturnValue({ value: mockUuid });
+
+      setCorrelationId(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(hooks.setHookCorrelationId).toHaveBeenCalledWith(mockUuid);
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('should prefer message attributes over header for correlation ID', () => {
+      const headerCorrelationId = 'header-correlation-id';
+      const attributeCorrelationId = 'attribute-correlation-id';
+      mockRequest.headers = {
+        'x-correlation-id': headerCorrelationId
+      };
+      mockRequest.body = {
+        message: {
+          attributes: {
+            correlationId: attributeCorrelationId
+          }
+        }
+      };
+
+      setCorrelationId(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(hooks.setHookCorrelationId).toHaveBeenCalledWith(attributeCorrelationId);
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
+
+  describe('set tenant id', () => {
+    const defaultTenantId = 'default-tenant';
+
+    it('should use tenant ID from header', () => {
+      const testTenantId = 'test-tenant';
+      mockRequest.headers = {
+        'x-tenant-id': testTenantId
+      };
+
+      const middleware = setTenantId(defaultTenantId);
+      middleware(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(hooks.setHookTenantId).toHaveBeenCalledWith(testTenantId);
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('should use default tenant ID if none provided in header', () => {
+      const middleware = setTenantId(defaultTenantId);
+      middleware(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(hooks.setHookTenantId).toHaveBeenCalledWith(defaultTenantId);
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## PR's Changes

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Refactor.

**What is the current behavior?** (You can also link to an open issue here)
It is not possible to pass a default value to the tenant context middleware.

**What is the new behavior (if this is a feature change)?**
We should be able to set a default value for tenant ID in case it is not provided via header.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes. Users should change the usage of `setTenantId` from:

```typescript
app.use(setContext, setTenantId);
```

To:
```typescript
app.use(setContext, setTenantId('sample-id'));
```

**Other information**:

## **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
