### PR TITLE
feat: add metadata fields to warn and error logs

### DIFF
--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -4,6 +4,8 @@ import { getHookCorrelationId } from './hooks';
 
 type Severity = 'debug' | 'info' | 'http' | 'warn' | 'error';
 
+type LogMetadata = Record<string, unknown> & { notify?: boolean };
+
 export class WinstonLogger {
     private static instance: winston.Logger | undefined;
 
@@ -85,11 +87,19 @@ export class Logger {
         this.log('http', message, meta, err);
     }
 
-    static warn(message: string, meta?: Record<string, unknown>, err?: unknown) {
-        this.log('warn', message, meta, err);
+    static warn(message: string, meta?: LogMetadata, err?: unknown) {
+        this.log('warn', message, this.formatMetadata(meta), err);
     }
 
-    static error(message: string, meta?: Record<string, unknown>, err?: unknown) {
-        this.log('error', message, meta, err);
+    static error(message: string, meta?: LogMetadata, err?: unknown) {
+        this.log('error', message, this.formatMetadata(meta), err);
+    }
+
+    private static formatMetadata(meta?: Partial<LogMetadata>) {
+        return {
+            ...meta,
+            notify: meta?.notify || false,
+            jsonString: meta ? JSON.stringify(meta) : undefined,
+        };
     }
 }


### PR DESCRIPTION
Precisamos dos campos `notify` e `jsonString`  para uma política de envio de erros da Algar. Nessa política os logs são analizados usando esses campos para enviar dados informativos de erros que recebemos a eles.