### PR TITLE
:bug: fix: upgrade npm and enable provenance for OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -50,5 +50,8 @@ jobs:
       - name: Build
         run: pnpm run build
 
+      - name: Upgrade NPM
+        run: npm install -g npm@latest
+
       - name: Publish
-        run: npm publish
+        run: npm publish --provenance


### PR DESCRIPTION
## Summary
- Install `npm@latest` before `npm publish` in the `publish-npm` job so OIDC trusted publishing actually happens. Node 22 ships npm 10.x, but npm trusted publishing via OIDC requires npm >= 11.5.1 (released Jul/2025); without it the publish request goes out anonymous and the npm registry returns 404 on the scoped package — same symptom we have been seeing on the v0.2.0 / v0.2.1 release runs.
- Pass `--provenance` to `npm publish`. The [official npm docs](https://docs.npmjs.com/trusted-publishers/) say provenance is implicit under trusted publishing and the flag is not needed, but [field reports](https://philna.sh/blog/2026/01/28/trusted-publishing-npm/) (Jan/2026) describe publishes still failing without it. Cost of keeping the flag is zero, so we add it preemptively to avoid an extra release iteration if the implicit path doesn't kick in.

## Context
- `@wave-tech/framework` failed to publish in attempts 1 and 3 of run [24355650450](https://github.com/wave-telecom/wave-tech-framework/actions/runs/24355650450) (v0.2.0) and run [24525444042](https://github.com/wave-telecom/wave-tech-framework/actions/runs/24525444042) (v0.2.1) with `npm error 404 Not Found - PUT https://registry.npmjs.org/@wave-tech%2fframework`.
- The CTO confirmed the GitHub repository is already authorized as a Trusted Publisher on the npmjs.com side, and the workflow already has `permissions: id-token: write`. The missing piece was the npm CLI version on the runner.
- 404 (and not 401) is expected: the npm registry returns 404 on scoped packages when the request lacks publish permission, to avoid leaking package existence.

## What is intentionally NOT in this PR
- `--access public` — `@wave-tech/framework` has been public since `v0.1.0`; the flag is a no-op after the first publish, so it would be redundant noise.

## Open risk to validate post-merge
- We did not visually confirm the Trusted Publisher config on `npmjs.com/package/@wave-tech/framework/access`. If `repository_owner`, `repository`, `workflow_filename`, or `environment` is misconfigured there, the publish will still 404 even after this fix. If this PR doesn't unblock the next release, that's the next thing to check.

## Test plan
- [ ] After merge, cut a patch release (e.g. `v0.2.2`) and confirm the `publish-npm` job succeeds.
- [ ] Verify the new version appears on https://www.npmjs.com/package/@wave-tech/framework.
- [ ] If publish still fails, check the Trusted Publisher config on npmjs.com — `repository_owner=wave-telecom`, `repository=wave-tech-framework`, `workflow_filename=npm-publish.yml`, `environment` empty — every field must match exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)