### PR TITLE
:bug: fix: use Corepack to upgrade npm on the publish runner

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -51,7 +51,9 @@ jobs:
         run: pnpm run build
 
       - name: Upgrade NPM
-        run: npm install -g npm@latest
+        run: |
+          corepack enable
+          corepack prepare npm@latest --activate
 
       - name: Publish
         run: npm publish --provenance


### PR DESCRIPTION
## Summary
- Replace `npm install -g npm@latest` with Corepack (`corepack enable && corepack prepare npm@latest --activate`) in the `Upgrade NPM` step of the `publish-npm` job.

## Why
The `v0.2.2` release run failed at the `Upgrade NPM` step with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

This is a known bug in the GitHub Actions runner toolcache — Node 22.22.2 ships there with a broken npm 10.9.7 missing the `promise-retry` module from its own dependency tree. Any `npm install -g npm@latest` triggers `@npmcli/arborist`, which needs `promise-retry`, and crashes before the upgrade completes.

Failing run: https://github.com/wave-telecom/wave-tech-framework/actions/runs/25140740088/job/73689655205

Reference: [actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883), [npm/cli#9151](https://github.com/npm/cli/issues/9151).

Corepack is bundled with Node 22 and lives outside npm's broken module tree, so it can install npm@latest cleanly.

## Test plan
- [ ] After merge, cut `v0.2.3` and confirm the `publish-npm` job succeeds.
- [ ] Verify the new version appears on https://www.npmjs.com/package/@wave-tech/framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)