### PR TITLE
:sparkles: feat: support custom transports in Logger.initialize

### DIFF
--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -6,10 +6,14 @@ type Severity = 'debug' | 'info' | 'http' | 'warn' | 'error';
 
 type LogMetadata = Record<string, unknown> & { notify?: boolean };
 
+export interface LoggerOptions {
+    transports?: winston.transport[];
+}
+
 export class WinstonLogger {
     private static instance: winston.Logger | undefined;
 
-    static getInstance(serviceName?: string) {
+    static getInstance(serviceName?: string, additionalTransports: winston.transport[] = []) {
         if (!this.instance) {
             this.instance = createLogger({
                 level: 'http',
@@ -31,6 +35,7 @@ export class WinstonLogger {
                 },
                 transports: [
                     new transports.Console(),
+                    ...additionalTransports,
                 ],
             });
         }
@@ -43,9 +48,9 @@ export class Logger {
 
     private constructor() { }
 
-    static initialize(serviceName: string) {
+    static initialize(serviceName: string, options?: LoggerOptions) {
         if (this.loggerInstance) return;
-        this.loggerInstance = WinstonLogger.getInstance(serviceName);
+        this.loggerInstance = WinstonLogger.getInstance(serviceName, options?.transports);
     }
 
     private static getLogger() {

--- a/tests/core/logger.spec.ts
+++ b/tests/core/logger.spec.ts
@@ -1,30 +1,24 @@
 import { describe, it, expect } from 'vitest';
-import Transport from 'winston-transport';
+import { PassThrough } from 'node:stream';
 import { transports as winstonTransports } from 'winston';
 import { Logger, WinstonLogger } from '../../src/core/logger';
 
-class FakeHttpTransport extends Transport {
-    logs: unknown[] = [];
-
-    override log(info: unknown, callback: () => void) {
-        this.logs.push(info);
-        callback();
-    }
-}
+const makeStreamTransport = () =>
+    new winstonTransports.Stream({ stream: new PassThrough() });
 
 describe('Logger.initialize with custom transports', () => {
     it('registers additional transports alongside default Console', () => {
-        const fake = new FakeHttpTransport();
-        Logger.initialize('test-service', { transports: [fake] });
+        const custom = makeStreamTransport();
+        Logger.initialize('test-service', { transports: [custom] });
 
         const instance = WinstonLogger.getInstance();
         expect(instance.transports).toHaveLength(2);
         expect(instance.transports[0]).toBeInstanceOf(winstonTransports.Console);
-        expect(instance.transports[1]).toBe(fake);
+        expect(instance.transports[1]).toBe(custom);
     });
 
     it('keeps singleton — second initialize does not replace transports', () => {
-        Logger.initialize('other-service', { transports: [new FakeHttpTransport()] });
+        Logger.initialize('other-service', { transports: [makeStreamTransport()] });
 
         const instance = WinstonLogger.getInstance();
         expect(instance.transports).toHaveLength(2);

--- a/tests/core/logger.spec.ts
+++ b/tests/core/logger.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import Transport from 'winston-transport';
+import { transports as winstonTransports } from 'winston';
+import { Logger, WinstonLogger } from '../../src/core/logger';
+
+class FakeHttpTransport extends Transport {
+    logs: unknown[] = [];
+
+    override log(info: unknown, callback: () => void) {
+        this.logs.push(info);
+        callback();
+    }
+}
+
+describe('Logger.initialize with custom transports', () => {
+    it('registers additional transports alongside default Console', () => {
+        const fake = new FakeHttpTransport();
+        Logger.initialize('test-service', { transports: [fake] });
+
+        const instance = WinstonLogger.getInstance();
+        expect(instance.transports).toHaveLength(2);
+        expect(instance.transports[0]).toBeInstanceOf(winstonTransports.Console);
+        expect(instance.transports[1]).toBe(fake);
+    });
+
+    it('keeps singleton — second initialize does not replace transports', () => {
+        Logger.initialize('other-service', { transports: [new FakeHttpTransport()] });
+
+        const instance = WinstonLogger.getInstance();
+        expect(instance.transports).toHaveLength(2);
+    });
+});


### PR DESCRIPTION
## O que muda

`Logger.initialize` agora aceita um segundo parâmetro opcional `options` com a chave `transports`, permitindo registrar transports adicionais do winston além do `Console` default — caso de uso imediato: enviar logs pro Datadog via HTTP.

```ts
import { Logger } from '@wave-tech/framework';
import { transports } from 'winston';

Logger.initialize('my-service', {
    transports: [
        new transports.Http({
            host: 'http-intake.logs.datadoghq.com',
            path: `/api/v2/logs?dd-api-key=${process.env.DD_API_KEY}&ddsource=nodejs&service=my-service`,
            ssl: true,
        }),
    ],
});
```

## Compatibilidade

✅ **100% backward compatible** — o parâmetro é completamente opcional:
- `Logger.initialize('my-service')` continua funcionando exatamente como antes (só Console).
- `WinstonLogger.getInstance(serviceName)` mantém a mesma assinatura, novo parâmetro tem default `[]`.
- Nenhuma assinatura existente foi alterada ou removida.

## Detalhes de implementação

- Novo tipo exportado `LoggerOptions` (`{ transports?: winston.transport[] }`) — extensível pra futuras opções sem novo breaking change.
- Transports extras são espalhados após o `Console` default no array de transports do winston.
- Semântica de singleton preservada: segunda chamada de `initialize` continua sendo no-op.

## Testes

- `tests/core/logger.spec.ts` (novo): valida registro de transport custom junto do Console e comportamento de singleton.
- `pnpm build` ✅ · `pnpm lint` ✅ · `pnpm test` ✅ (49 testes passando)

🤖 Generated with [Claude Code](https://claude.com/claude-code)