### PR TITLE
:sparkles: feat(audit): change history via atomic Prisma audit extension (TIM-2259)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
   },
   "author": "",
   "license": "Apache-2.0",
+  "peerDependencies": {
+    "@prisma/client": ">=6.3.1"
+  },
   "dependencies": {
-    "@prisma/client": "^6.3.1",
     "date-fns": "^4.1.0",
     "express": "^4.21.2",
     "google-auth-library": "^9.15.1",
@@ -35,6 +37,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
+    "@prisma/client": "^6.3.1",
     "@types/express": "^5.0.0",
     "@types/node": "^24.0.0",
     "@typescript-eslint/parser": "^8.24.0",
@@ -93,6 +96,11 @@
       "types": "./dist/clients/index.d.ts",
       "require": "./dist/clients/index.js",
       "default": "./dist/clients/index.js"
+    },
+    "./audit": {
+      "types": "./dist/audit/index.d.ts",
+      "require": "./dist/audit/index.js",
+      "default": "./dist/audit/index.js"
     }
   },
   "typesVersions": {
@@ -114,6 +122,9 @@
       ],
       "clients": [
         "./dist/clients/index.d.ts"
+      ],
+      "audit": [
+        "./dist/audit/index.d.ts"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wave-tech/framework",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "wave tech team shared utils framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@prisma/client':
-        specifier: ^6.3.1
-        version: 6.3.1(typescript@5.7.3)
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -39,6 +36,9 @@ importers:
       '@eslint/js':
         specifier: ^9.20.0
         version: 9.20.0
+      '@prisma/client':
+        specifier: ^6.3.1
+        version: 6.3.1(typescript@5.7.3)
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.0
@@ -1988,6 +1988,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:

--- a/src/audit/README.md
+++ b/src/audit/README.md
@@ -1,0 +1,163 @@
+# @wave-tech/framework/audit
+
+Padrão de **Audit Events**: captura automática das mudanças de entidade
+(Created / Updated / Deleted) e grava um evento no **mesmo commit** da escrita de
+negócio, via Prisma Client Extension. O motor mora no framework; cada API só
+fornece a **configuração** (o que auditar) e a **tabela de transporte** (`outbox`)
+no seu schema.
+
+> Nomenclatura: **"audit"** é o padrão (trilha de quem mudou o quê, com
+> before/after). O **`outbox`** é apenas o transporte (tabela onde o evento é
+> gravado e de onde o relay publica). Um não é sinônimo do outro.
+
+## O que o framework fornece
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `audit-context.ts` | ALS que carrega o `tx` da transação ativa até a extension. |
+| `registry.ts` | Guarda o client estendido (`registerAuditedClient`). |
+| `run-in-transaction.ts` | `withTransaction` — abre/junta transação e publica o `tx` no ALS. |
+| `audit-actor.ts` | `getAuditActor()` — lê `userId`/`correlationId` dos hooks de request. |
+| `build-audit-event.ts` | Contrato do evento: nome (`${prefix}${Model}Created/Updated/Deleted`), payload, diff, serialização segura. |
+| `create-audit-extension.ts` | Factory da Prisma extension a partir da config da API + guardas. |
+
+## O que fica na API
+
+1. **Tabela de transporte no schema** (colunas padronizadas):
+
+```prisma
+model Outbox {
+  id           String    @id @db.Uuid
+  resourceId   String    @map("resource_id") @db.Uuid
+  resourceType String    @map("resource_type") @db.VarChar(256)
+  eventType    String    @map("event_type") @db.VarChar(256)
+  payload      Json
+  published    Boolean   @default(false)
+  publishedAt  DateTime? @map("published_at") @db.Timestamptz(6)
+  createdAt    DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+
+  @@index([published, createdAt])
+  @@map("outbox")
+}
+```
+
+2. **Config + wiring no boot** (o app usa o client estendido em todo lugar):
+
+```typescript
+import { createAuditExtension, registerAuditedClient } from '@wave-tech/framework/audit';
+
+const auditExtension = createAuditExtension({
+  Broker: { operations: new Set(['upsert']), emitOn: new Set(['CREATE', 'UPDATE']) },
+  // eventPrefix default = 'Audit.' -> Audit.BrokerCreated, Audit.BrokerUpdated
+});
+
+const prisma = new PrismaClient();
+const audited = prisma.$extends(auditExtension) as unknown as PrismaClient;
+registerAuditedClient(audited); // withTransaction e o auto-wrap usam este client
+// devolva `audited` para os repositórios/DI
+```
+
+## Formas suportadas de escrever um model auditado
+
+Todas gravam o evento no MESMO commit da escrita. A extension descobre a
+transação de três formas:
+
+1. **`withTransaction` — recomendado (API pública).** Sempre para múltiplas
+   escritas atômicas; serve também para escrita única.
+   ```typescript
+   import { withTransaction } from '@wave-tech/framework/audit';
+   await withTransaction(async (tx) => {
+     await tx.broker.upsert({ where: { id }, create: {...}, update: {...} });
+   });
+   ```
+2. **`prisma.$transaction(async (tx) => ...)` cru.** A extension detecta a
+   transação interativa (via `__internalParams`) e grava o evento nela.
+3. **Escrita isolada direta no client** (ex.: `db.productProvider.upsert(...)`).
+   A extension faz auto-wrap: abre a transação e grava o evento junto, atômico.
+   Ideal para agregado de tabela única.
+
+### A ÚNICA forma proibida
+
+`prisma.$transaction([...])` em **array (batch)** contendo escrita de model
+auditado → a extension **lança erro** (o batch não expõe um `tx` interativo).
+Converta para escritas sequenciais dentro de `withTransaction` (ou de um
+`$transaction` interativo).
+
+> Nota técnica: as formas (2) e (3) usam APIs internas do Prisma
+> (`__internalParams` / `_createItxClient`), validadas na 6.8. Se um upgrade do
+> Prisma quebrá-las, o `withTransaction` (API pública) continua funcionando — por
+> isso ele é o caminho recomendado.
+
+## Diff de campos (opcional, desligado por padrão)
+
+Por padrão o `payload.changes` de um UPDATE vem `null` (não calcula o diff nem
+lê o registro anterior). Para habilitar num model, marque `diff: true` na regra:
+
+```typescript
+createAuditExtension({
+  Broker: { operations: new Set(['upsert']), emitOn: new Set(['CREATE','UPDATE']), diff: true },
+});
+```
+
+Com `diff: true`, o UPDATE preenche `changes: { campo: { from, to } }` (a
+extension faz um `findUnique` do "before" para montá-lo).
+
+## Chave primária (`resourceId`)
+
+O `resourceId` é lido do campo `id` do registro por padrão. Se o model usar outra
+PK, informe `idField` na regra:
+
+```typescript
+createAuditExtension({
+  UserProfile: {
+    operations: new Set(['update']),
+    emitOn: new Set(['UPDATE']),
+    idField: 'userId',
+  },
+});
+```
+
+Se o campo configurado não existir no registro, o `resourceId` sai vazio (`''`) e
+um `warn` é logado, em vez de gravar a string literal `"undefined"`.
+
+## eventType e prefixo (namespace)
+
+O `eventType` segue `${prefix}${Model}${Created|Updated|Deleted}`. O `eventPrefix`
+é opção da extension, default `'Audit.'` — ex.: `Audit.BrokerCreated`. Facilita o
+filtro no consumidor (`startsWith('Audit.')`). Passe `eventPrefix: ''` para
+desativar o namespace.
+
+## Contrato do evento (payload)
+
+```jsonc
+{
+  "operation": "CREATE | UPDATE | DELETE",
+  "occurredAt": "2026-07-06T12:00:00.000Z",
+  "actorId": "user-123 | null",
+  "correlationId": "…",
+  "changes": null,          // null em CREATE; { campo: { from, to } } em UPDATE (se diff on)
+  "snapshot": { /* linha após a escrita (ou before em DELETE) */ }
+}
+```
+
+## Guardas embutidas
+
+- `createMany/updateMany/deleteMany` em model auditado → lança erro (não há
+  "before" por linha).
+- `prisma.$transaction([...])` (batch array) com model auditado → lança erro.
+- A tabela de transporte (`outbox`) nunca deve entrar na config (evita recursão).
+- Teste de consistência sugerido no CI de cada API:
+
+```typescript
+it('todo agregado auditável está registrado', () => {
+  const faltando = listAuditableAggregates().filter((m) => !auditedModelsOf(config).has(m));
+  expect(faltando).toEqual([]);
+});
+```
+
+## Dependências
+
+- `@prisma/client` como **peerDependency** (usa `Prisma.defineExtension`; o tipo
+  do `tx` resolve para o client gerado do consumidor).
+- Hooks de request do framework: `setContext` + `setCorrelationId` + `setUserId`
+  (o `getAuditActor` lê `getHookUserId`/`getHookCorrelationId`).

--- a/src/audit/audit-actor.ts
+++ b/src/audit/audit-actor.ts
@@ -1,0 +1,18 @@
+import { getHookCorrelationId, getHookUserId } from '../core/hooks';
+
+/**
+ * Actor/correlation resolvers for audit events, backed by the framework's
+ * per-request hook context (opened by the `setContext` middleware). Single
+ * source of coupling with the hooks — if the source changes, change it here.
+ */
+export interface AuditActor {
+  actorId: string | null;
+  correlationId: string | null;
+}
+
+export function getAuditActor(): AuditActor {
+  return {
+    actorId: getHookUserId() ?? null,
+    correlationId: getHookCorrelationId() ?? null,
+  };
+}

--- a/src/audit/audit-context.ts
+++ b/src/audit/audit-context.ts
@@ -1,0 +1,32 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { PrismaClient } from '@prisma/client';
+
+/**
+ * The Prisma interactive-transaction client. Because `@prisma/client` is a peer
+ * dependency, this type resolves to the CONSUMER's generated client (with its
+ * own models) at their compile time — so callers get a fully-typed `tx` with no
+ * cast. We omit the connection-level methods that don't exist inside an
+ * interactive transaction.
+ */
+export type AuditTransactionClient = Omit<
+  PrismaClient,
+  '$connect' | '$disconnect' | '$on' | '$transaction' | '$use' | '$extends'
+>;
+
+/**
+ * Context carried through the async chain of an audited write. It exists only
+ * to propagate the active transaction (`tx`) from `withTransaction` down to
+ * the audit extension, so the audit event is written in the SAME transaction as
+ * the business write. Actor/correlation are read from the request hooks at emit
+ * time (see audit-actor.ts), not stored here.
+ */
+export interface AuditContext {
+  tx?: AuditTransactionClient;
+}
+
+export const auditContextStorage = new AsyncLocalStorage<AuditContext>();
+
+/** Current audit context, or an empty one when outside an audited transaction. */
+export function getAuditContext(): AuditContext {
+  return auditContextStorage.getStore() ?? {};
+}

--- a/src/audit/build-audit-event.ts
+++ b/src/audit/build-audit-event.ts
@@ -1,0 +1,113 @@
+import { randomUUID } from 'node:crypto';
+import type { AuditActor } from './audit-actor';
+import { Logger } from '../core/logger';
+
+export type AuditableOperation = 'create' | 'update' | 'delete' | 'upsert';
+export type OperationKind = 'CREATE' | 'UPDATE' | 'DELETE';
+
+export type JsonValue =
+  | string | number | boolean | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/**
+ * Shape written to the audit transport (`outbox`) table. Matches the
+ * standardized columns; published/publishedAt/createdAt use their DB defaults.
+ */
+export interface AuditEvent {
+  id: string;
+  resourceId: string;
+  resourceType: string;
+  eventType: string;
+  payload: Record<string, JsonValue | null>;
+}
+
+/**
+ * Resolves the semantic kind of a write. For `upsert` the presence of a
+ * previous row (`before`) decides between an insert and an update.
+ */
+export function resolveOperationKind(
+  operation: AuditableOperation,
+  before: unknown,
+): OperationKind {
+  if (operation === 'create') return 'CREATE';
+  if (operation === 'delete') return 'DELETE';
+  if (operation === 'upsert') return before ? 'UPDATE' : 'CREATE';
+  return 'UPDATE';
+}
+
+/** Date -> ISO string, Decimal -> toJSON(), etc. — safe for a JSON column. */
+function toJsonSafe(value: unknown): JsonValue | null {
+  if (value === null || value === undefined) return null;
+  return JSON.parse(JSON.stringify(value)) as JsonValue;
+}
+
+/** Shallow diff of changed fields (field -> { from, to }). */
+export function diff(
+  before: Record<string, unknown> | null,
+  after: Record<string, unknown> | null,
+): JsonValue | null {
+  if (!before || !after) return null;
+  const changes: Record<string, { from: unknown; to: unknown }> = {};
+  for (const key of new Set([...Object.keys(before), ...Object.keys(after)])) {
+    if (JSON.stringify(before[key]) !== JSON.stringify(after[key])) {
+      changes[key] = { from: before[key], to: after[key] };
+    }
+  }
+  return toJsonSafe(changes);
+}
+
+interface BuildArgs {
+  model: string;
+  operation: AuditableOperation;
+  before: Record<string, unknown> | null;
+  after: Record<string, unknown> | null;
+  actor: AuditActor;
+  /** When true, compute the field-level diff for UPDATE events. Default: false. */
+  computeDiff?: boolean;
+  /**
+   * Prepended to the eventType, e.g. 'Audit.' -> 'Audit.BrokerCreated'.
+   * Default: 'Audit.'. Pass '' to disable.
+   */
+  eventPrefix?: string;
+  /** Primary-key field read for `resourceId`. Default: 'id'. */
+  idField?: string;
+}
+
+export function buildAuditEvent({
+  model,
+  operation,
+  before,
+  after,
+  actor,
+  computeDiff = false,
+  eventPrefix = 'Audit.',
+  idField = 'id',
+}: BuildArgs): AuditEvent {
+  const op = resolveOperationKind(operation, before);
+  const suffix = op === 'CREATE' ? 'Created' : op === 'DELETE' ? 'Deleted' : 'Updated';
+  const source = after ?? before ?? {};
+
+  const rawId = (source as Record<string, unknown>)[idField];
+  if (rawId === undefined || rawId === null) {
+    Logger.warn(
+      `Audit event for "${model}" has no "${idField}" value; resourceId will be empty. `
+      + 'Set "idField" on the audit rule if this model uses a different primary key.',
+    );
+  }
+
+  return {
+    id: randomUUID(),
+    resourceType: model,
+    resourceId: rawId === undefined || rawId === null ? '' : String(rawId),
+    eventType: `${eventPrefix}${model}${suffix}`,
+    payload: {
+      operation: op,
+      occurredAt: new Date().toISOString(),
+      actorId: actor.actorId,
+      correlationId: actor.correlationId,
+      changes: op === 'CREATE' || !computeDiff ? null : diff(before, after),
+      snapshot: op === 'DELETE' ? toJsonSafe(before) : toJsonSafe(after),
+    },
+  };
+}

--- a/src/audit/create-audit-extension.ts
+++ b/src/audit/create-audit-extension.ts
@@ -1,0 +1,166 @@
+import { Prisma } from '@prisma/client';
+import { getAuditActor } from './audit-actor';
+import { getAuditContext } from './audit-context';
+import type { AuditableOperation, OperationKind } from './build-audit-event';
+import { buildAuditEvent, resolveOperationKind } from './build-audit-event';
+import { getAuditedClient } from './registry';
+import { Logger } from '../core/logger';
+
+export interface AuditRule {
+  /** Prisma operations that are intercepted for this model. */
+  operations: Set<AuditableOperation>;
+  /** Which resolved kinds actually emit an audit event. */
+  emitOn: Set<OperationKind>;
+  /**
+   * When true, compute the field-level diff (payload.changes) for UPDATE
+   * events. Off by default — enabling it also reads the previous row (an extra
+   * findUnique) to build the diff.
+   */
+  diff?: boolean;
+  /** Primary-key field read for `resourceId`. Default: 'id'. */
+  idField?: string;
+}
+
+/** model name -> rule. NEVER include the audit transport model itself (recursion). */
+export type AuditConfig = Record<string, AuditRule>;
+
+export interface AuditExtensionOptions {
+  /** Lowercased Prisma model name for the audit transport table. Default: 'outbox'. */
+  transportModel?: string;
+  /** Actor/correlation resolver. Default: reads the framework request hooks. */
+  resolveActor?: typeof getAuditActor;
+  /**
+   * Namespace prepended to every eventType, e.g. 'Audit.'.
+   * Default: 'Audit.'. Pass '' to disable.
+   */
+  eventPrefix?: string;
+}
+
+const BULK_OPS = new Set(['createMany', 'updateMany', 'deleteMany']);
+const lowerFirst = (s: string): string => s.charAt(0).toLowerCase() + s.slice(1);
+
+/**
+ * The "before" row is needed to resolve the kind of an upsert, for the snapshot
+ * of a delete, and to compute the diff of an update (only when diff is on).
+ */
+const needsBefore = (op: AuditableOperation, wantsDiff: boolean): boolean =>
+  op === 'upsert' || op === 'delete' || (op === 'update' && wantsDiff);
+
+// Structural view used to dispatch dynamically on the tx inside the extension
+// (the public `tx` is the consumer's fully-typed PrismaClient).
+interface Delegate { findUnique: (a: unknown)=> Promise<unknown> }
+type TxWithTransport = Record<string, Delegate>
+  & Record<string, { create: (a: unknown)=> Promise<unknown> }>;
+type TxDispatch = Record<string, Record<string, (a: unknown)=> Promise<unknown>>>;
+
+// Prisma surfaces the current transaction to query extensions via this internal
+// param. `_createItxClient` rebuilds a client bound to that interactive tx.
+// Both are INTERNAL Prisma APIs (undocumented) — validated on 6.8. If a Prisma
+// upgrade changes them, only the auto-wrap / raw-$transaction convenience breaks;
+// the official `withTransaction` (ALS) path keeps working.
+interface InternalTransaction { kind?: 'itx' | 'batch' }
+interface ClientWithItx { _createItxClient: (tx: InternalTransaction)=> unknown }
+
+/**
+ * Builds the audit Prisma Client extension for a given audit config. The API
+ * passes its own config; everything else (before-capture, atomic write, guards,
+ * event contract) is provided here.
+ */
+export function createAuditExtension(config: AuditConfig, options: AuditExtensionOptions = {}) {
+  const transportModel = options.transportModel ?? 'outbox';
+  const resolveActor = options.resolveActor ?? getAuditActor;
+  const eventPrefix = options.eventPrefix ?? 'Audit.';
+
+  return Prisma.defineExtension((client) =>
+    client.$extends({
+      name: 'audit-extension',
+      query: {
+        $allModels: {
+          async $allOperations({ args, query, model, operation, ...rest }) {
+            const rule = model ? config[model] : undefined;
+            if (!model || !rule?.operations.has(operation as AuditableOperation)) {
+              return query(args);
+            }
+
+            Logger.debug(`Audited model "${model}" is being written via "${operation}". The audit event will be emitted atomically.`);
+
+            if (BULK_OPS.has(operation)) {
+              const msg = `Bulk operation "${operation}" is not allowed on audited model "${model}". Use withTransaction with a create/update/delete loop.`;
+              Logger.error(msg);
+              throw new Error(msg);
+            }
+
+            const auditedOp = operation as AuditableOperation;
+            const wantsDiff = rule.diff ?? false;
+
+            // Captures `before`, runs the business op via `query(args)` (which
+            // executes in the CURRENT tx), then writes the outbox row on the
+            // SAME tx. Never re-dispatches through the client here.
+            const emit = async (tx: TxWithTransport): Promise<Record<string, unknown> | null> => {
+              const before = needsBefore(auditedOp, wantsDiff)
+                ? ((await tx[lowerFirst(model)].findUnique({
+                    where: (args as { where?: unknown }).where,
+                  })) as Record<string, unknown> | null)
+                : null;
+
+              const after = (await query(args)) as Record<string, unknown> | null;
+
+              const kind = resolveOperationKind(auditedOp, before);
+              if (rule.emitOn.has(kind)) {
+                await tx[transportModel].create({
+                  data: buildAuditEvent({
+                    model,
+                    operation: auditedOp,
+                    before,
+                    after,
+                    actor: resolveActor(),
+                    computeDiff: wantsDiff,
+                    eventPrefix,
+                    idField: rule.idField,
+                  }),
+                });
+              }
+              Logger.debug(`Audited model "${model}" emitted an event for "${operation}".`);
+              return after;
+            };
+
+            // (1) Official path: tx propagated through the ALS (withTransaction).
+            const ctx = getAuditContext();
+            if (ctx.tx) return emit(ctx.tx as unknown as TxWithTransport);
+
+            // (2) Otherwise, detect the current tx from Prisma's internal params.
+            // Covers a raw `prisma.$transaction(async tx => ...)` AND the
+            // re-dispatch from the auto-wrap in (3). `_createItxClient` gives us a
+            // client bound to that interactive tx, so the outbox write lands in
+            // the same commit.
+            const internalTx = (
+              rest as { __internalParams?: { transaction?: InternalTransaction } }
+            ).__internalParams?.transaction;
+
+            if (internalTx?.kind === 'batch') {
+              const msg = `Audited model "${model}" cannot be written inside a batch $transaction([...]). Use withTransaction or a raw interactive $transaction(async (tx) => ...).`;
+              Logger.error(msg);
+              throw new Error(msg);
+            }
+
+            if (internalTx?.kind === 'itx') {
+              Logger.debug(`Audited model "${model}" is being written inside a raw interactive $transaction. The audit event will be emitted atomically.`);
+              const itxClient = (client as unknown as ClientWithItx)._createItxClient(internalTx);
+              return emit(itxClient as TxWithTransport);
+            }
+
+            // (3) No transaction at all -> auto-wrap: open one and re-dispatch the
+            // op ON the tx (so `query` runs in it); the re-invocation lands on (2)
+            // as 'itx' and emits the event atomically.
+            return getAuditedClient().$transaction((tx) =>
+              (tx as unknown as TxDispatch)[lowerFirst(model)][operation](args),
+            );
+          },
+        },
+      },
+    }),
+  );
+}
+
+/** Set of audited model names — feed the CI consistency test (see README §9). */
+export const auditedModelsOf = (config: AuditConfig): Set<string> => new Set(Object.keys(config));

--- a/src/audit/index.ts
+++ b/src/audit/index.ts
@@ -1,0 +1,6 @@
+export * from './audit-context';
+export * from './registry';
+export * from './run-in-transaction';
+export * from './audit-actor';
+export * from './build-audit-event';
+export * from './create-audit-extension';

--- a/src/audit/registry.ts
+++ b/src/audit/registry.ts
@@ -1,0 +1,25 @@
+import type { AuditTransactionClient } from './audit-context';
+
+/**
+ * The extended Prisma client (client.$extends(auditExtension)) registered by the
+ * app at boot. Shared by withTransaction (to open transactions) and by the
+ * extension's auto-wrap path.
+ */
+export interface AuditClient {
+  $transaction: <T>(fn: (tx: AuditTransactionClient)=> Promise<T>)=> Promise<T>;
+}
+
+let auditClient: AuditClient | undefined;
+
+export const registerAuditedClient = (client: AuditClient): void => {
+  auditClient = client;
+};
+
+export const getAuditedClient = (): AuditClient => {
+  if (!auditClient) {
+    throw new Error(
+      'Audited Prisma client not registered. Call registerAuditedClient(client.$extends(auditExtension)) at boot.',
+    );
+  }
+  return auditClient;
+};

--- a/src/audit/run-in-transaction.ts
+++ b/src/audit/run-in-transaction.ts
@@ -1,0 +1,21 @@
+import type { AuditTransactionClient } from './audit-context';
+import { auditContextStorage, getAuditContext } from './audit-context';
+import { getAuditedClient } from './registry';
+
+/**
+ * Opens (or joins) an audited transaction and puts its client in the ALS so the
+ * audit extension writes each event into the SAME transaction as the business
+ * write. Always use this instead of a raw prisma.$transaction for audited writes.
+ */
+export function withTransaction<T>(
+  fn: (tx: AuditTransactionClient)=> Promise<T>,
+): Promise<T> {
+  const ctx = getAuditContext();
+
+  // Already in a transaction -> join it (single commit).
+  if (ctx.tx) return fn(ctx.tx);
+
+  return getAuditedClient().$transaction((tx) =>
+    auditContextStorage.run({ tx }, () => fn(tx)),
+  );
+}

--- a/src/core/hooks.ts
+++ b/src/core/hooks.ts
@@ -3,6 +3,7 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 interface HookContext {
     correlationId: string | undefined;
     tenantId: string | undefined;
+    userId: string | undefined;
     logMetadata: Record<string, unknown> | undefined;
 }
 
@@ -42,6 +43,16 @@ export const getHookTenantId = () => {
     const tenantId = context.get('tenantId') as string | undefined;
     if (!tenantId) throw new Error('Tenant ID not found');
     return tenantId;
+};
+
+export const setHookUserId = (userId: string) => {
+    const context = getHookContext();
+    context.set('userId', userId);
+};
+
+export const getHookUserId = (): string | undefined => {
+    const context = getHookContext();
+    return context.get('userId') as string | undefined;
 };
 
 export function setHookLogMetadata(metadata: Record<string, unknown>): void;

--- a/src/middlewares/context.ts
+++ b/src/middlewares/context.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
 import type { Context, Next } from 'hono';
-import { setHookContext, setHookCorrelationId, setHookTenantId } from '../core/hooks';
+import { setHookContext, setHookCorrelationId, setHookTenantId, setHookUserId } from '../core/hooks';
 import { Uuid } from '../core/uuid';
 
 export const setContext = (req: Request, res: Response, next: NextFunction) => {
@@ -30,6 +30,12 @@ export const setTenantId = (defaultTenantId?: string) => {
     };
 };
 
+export const setUserId = (req: Request, res: Response, next: NextFunction) => {
+    const userId = req.headers['x-user-id'] as string | undefined;
+    if (userId) setHookUserId(userId);
+    next();
+};
+
 export const setContextHono = async (ctx: Context, next: Next) => {
     await setHookContext(() => next());
 };
@@ -53,4 +59,10 @@ export const setTenantIdHono = (defaultTenantId?: string) => {
         setHookTenantId(tenantId);
         await next();
     };
+};
+
+export const setUserIdHono = (ctx: Context, next: Next) => {
+    const userId = ctx.req.header('x-user-id');
+    if (userId) setHookUserId(userId);
+    return next();
 };

--- a/tests/audit/audit-actor.spec.ts
+++ b/tests/audit/audit-actor.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { getAuditActor } from '../../src/audit/audit-actor';
+import {
+  setHookContext,
+  setHookCorrelationId,
+  setHookUserId,
+} from '../../src/core/hooks';
+
+describe('getAuditActor', () => {
+  it('reads actorId and correlationId from the request hook context', () => {
+    setHookContext(() => {
+      setHookUserId('user-123');
+      setHookCorrelationId('corr-abc');
+
+      expect(getAuditActor()).toEqual({
+        actorId: 'user-123',
+        correlationId: 'corr-abc',
+      });
+    });
+  });
+
+  it('falls back to null when there is no hook context', () => {
+    expect(getAuditActor()).toEqual({ actorId: null, correlationId: null });
+  });
+});

--- a/tests/audit/build-audit-event.spec.ts
+++ b/tests/audit/build-audit-event.spec.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildAuditEvent,
+  diff,
+  resolveOperationKind,
+} from '../../src/audit/build-audit-event';
+import type { AuditActor } from '../../src/audit/audit-actor';
+import { Logger } from '../../src/core/logger';
+
+const actor: AuditActor = { actorId: 'user-1', correlationId: 'corr-1' };
+
+describe('resolveOperationKind', () => {
+  it('maps create -> CREATE and delete -> DELETE', () => {
+    expect(resolveOperationKind('create', null)).toBe('CREATE');
+    expect(resolveOperationKind('delete', { id: 1 })).toBe('DELETE');
+  });
+
+  it('maps update -> UPDATE', () => {
+    expect(resolveOperationKind('update', { id: 1 })).toBe('UPDATE');
+  });
+
+  it('resolves upsert by presence of the previous row', () => {
+    expect(resolveOperationKind('upsert', null)).toBe('CREATE');
+    expect(resolveOperationKind('upsert', { id: 1 })).toBe('UPDATE');
+  });
+});
+
+describe('diff', () => {
+  it('returns null when either side is missing', () => {
+    expect(diff(null, { a: 1 })).toBeNull();
+    expect(diff({ a: 1 }, null)).toBeNull();
+  });
+
+  it('reports only the changed fields as { from, to }', () => {
+    expect(diff({ a: 1, b: 2 }, { a: 1, b: 3 })).toEqual({
+      b: { from: 2, to: 3 },
+    });
+  });
+
+  it('captures added and removed keys', () => {
+    expect(diff({ a: 1 }, { a: 1, c: 9 })).toEqual({
+      c: { from: undefined, to: 9 },
+    });
+  });
+
+  it('is JSON-safe (Date -> ISO string)', () => {
+    const before = { at: new Date('2020-01-01T00:00:00.000Z') };
+    const after = { at: new Date('2021-01-01T00:00:00.000Z') };
+    expect(diff(before, after)).toEqual({
+      at: { from: '2020-01-01T00:00:00.000Z', to: '2021-01-01T00:00:00.000Z' },
+    });
+  });
+});
+
+describe('buildAuditEvent', () => {
+  it('builds a CREATE event: Created suffix, snapshot = after, no changes', () => {
+    const event = buildAuditEvent({
+      model: 'Broker',
+      operation: 'create',
+      before: null,
+      after: { id: 42, name: 'ACME' },
+      actor,
+    });
+
+    expect(event.resourceType).toBe('Broker');
+    expect(event.resourceId).toBe('42');
+    expect(event.eventType).toBe('Audit.BrokerCreated');
+    expect(event.payload.operation).toBe('CREATE');
+    expect(event.payload.actorId).toBe('user-1');
+    expect(event.payload.correlationId).toBe('corr-1');
+    expect(event.payload.changes).toBeNull();
+    expect(event.payload.snapshot).toEqual({ id: 42, name: 'ACME' });
+    expect(typeof event.id).toBe('string');
+    expect(typeof event.payload.occurredAt).toBe('string');
+  });
+
+  it('builds a DELETE event: Deleted suffix, snapshot = before', () => {
+    const event = buildAuditEvent({
+      model: 'Broker',
+      operation: 'delete',
+      before: { id: 7, name: 'old' },
+      after: null,
+      actor,
+    });
+
+    expect(event.eventType).toBe('Audit.BrokerDeleted');
+    expect(event.payload.operation).toBe('DELETE');
+    expect(event.payload.snapshot).toEqual({ id: 7, name: 'old' });
+    expect(event.payload.changes).toBeNull();
+  });
+
+  it('omits changes on UPDATE when computeDiff is false (default)', () => {
+    const event = buildAuditEvent({
+      model: 'Broker',
+      operation: 'update',
+      before: { id: 1, name: 'a' },
+      after: { id: 1, name: 'b' },
+      actor,
+    });
+
+    expect(event.eventType).toBe('Audit.BrokerUpdated');
+    expect(event.payload.changes).toBeNull();
+    expect(event.payload.snapshot).toEqual({ id: 1, name: 'b' });
+  });
+
+  it('computes changes on UPDATE when computeDiff is true', () => {
+    const event = buildAuditEvent({
+      model: 'Broker',
+      operation: 'update',
+      before: { id: 1, name: 'a' },
+      after: { id: 1, name: 'b' },
+      actor,
+      computeDiff: true,
+    });
+
+    expect(event.payload.changes).toEqual({ name: { from: 'a', to: 'b' } });
+  });
+
+  it('resolves upsert suffix from the previous row', () => {
+    const created = buildAuditEvent({
+      model: 'Broker', operation: 'upsert', before: null, after: { id: 1 }, actor,
+    });
+    const updated = buildAuditEvent({
+      model: 'Broker', operation: 'upsert', before: { id: 1 }, after: { id: 1 }, actor,
+    });
+
+    expect(created.eventType).toBe('Audit.BrokerCreated');
+    expect(updated.eventType).toBe('Audit.BrokerUpdated');
+  });
+
+  it('honors a custom eventPrefix and disables it with an empty string', () => {
+    const prefixed = buildAuditEvent({
+      model: 'Broker', operation: 'create', before: null, after: { id: 1 }, actor,
+      eventPrefix: 'History.',
+    });
+    const bare = buildAuditEvent({
+      model: 'Broker', operation: 'create', before: null, after: { id: 1 }, actor,
+      eventPrefix: '',
+    });
+
+    expect(prefixed.eventType).toBe('History.BrokerCreated');
+    expect(bare.eventType).toBe('BrokerCreated');
+  });
+
+  it('reads resourceId from a configurable idField', () => {
+    const event = buildAuditEvent({
+      model: 'UserProfile',
+      operation: 'update',
+      before: { userId: 'u-9' },
+      after: { userId: 'u-9' },
+      actor,
+      idField: 'userId',
+    });
+
+    expect(event.resourceId).toBe('u-9');
+  });
+
+  describe('when the primary key is absent', () => {
+    beforeEach(() => {
+      vi.spyOn(Logger, 'warn').mockImplementation(() => undefined);
+    });
+
+    it('emits an empty resourceId and warns instead of the literal "undefined"', () => {
+      const event = buildAuditEvent({
+        model: 'Broker',
+        operation: 'create',
+        before: null,
+        after: { name: 'no-id-here' },
+        actor,
+      });
+
+      expect(event.resourceId).toBe('');
+      expect(event.resourceId).not.toBe('undefined');
+      expect(Logger.warn).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/tests/audit/registry.spec.ts
+++ b/tests/audit/registry.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { getAuditedClient, registerAuditedClient } from '../../src/audit/registry';
+
+describe('audited client registry', () => {
+  // Runs first: module state is fresh per test file, so no client is set yet.
+  it('throws a helpful error before a client is registered', () => {
+    expect(() => getAuditedClient()).toThrowError(/not registered/i);
+  });
+
+  it('returns the registered extended client', () => {
+    const client = { $transaction: () => Promise.resolve(undefined) } as never;
+    registerAuditedClient(client);
+    expect(getAuditedClient()).toBe(client);
+  });
+});

--- a/tests/audit/run-in-transaction.spec.ts
+++ b/tests/audit/run-in-transaction.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type AuditTransactionClient,
+  auditContextStorage,
+  getAuditContext,
+} from '../../src/audit/audit-context';
+import { registerAuditedClient } from '../../src/audit/registry';
+import { withTransaction } from '../../src/audit/run-in-transaction';
+
+const fakeTx = { marker: 'tx' } as unknown as AuditTransactionClient;
+
+describe('withTransaction', () => {
+  it('opens a new transaction and exposes tx through the audit context', async () => {
+    const $transaction = vi.fn((fn: (tx: AuditTransactionClient) => Promise<unknown>) =>
+      fn(fakeTx),
+    );
+    registerAuditedClient({ $transaction } as never);
+
+    let seenInsideCtx: AuditTransactionClient | undefined;
+    const result = await withTransaction((tx) => {
+      seenInsideCtx = getAuditContext().tx;
+      expect(tx).toBe(fakeTx);
+      return Promise.resolve('done');
+    });
+
+    expect(result).toBe('done');
+    expect($transaction).toHaveBeenCalledOnce();
+    // The active tx is propagated through the ALS so the extension writes into it.
+    expect(seenInsideCtx).toBe(fakeTx);
+  });
+
+  it('joins the existing transaction instead of opening a nested one', async () => {
+    const $transaction = vi.fn();
+    registerAuditedClient({ $transaction } as never);
+
+    const outerTx = { marker: 'outer' } as unknown as AuditTransactionClient;
+
+    const result = await auditContextStorage.run({ tx: outerTx }, () =>
+      withTransaction((tx) => {
+        expect(tx).toBe(outerTx);
+        return Promise.resolve('joined');
+      }),
+    );
+
+    expect(result).toBe('joined');
+    // Already inside a transaction -> must NOT open another (single commit).
+    expect($transaction).not.toHaveBeenCalled();
+  });
+});

--- a/tests/middlewares/context.spec.ts
+++ b/tests/middlewares/context.spec.ts
@@ -5,7 +5,7 @@ import type { Mock } from 'vitest';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as hooks from '../../src/core/hooks';
 import { Uuid } from '../../src/core/uuid';
-import { setContext, setContextHono, setCorrelationId, setCorrelationIdHono, setTenantId, setTenantIdHono } from '../../src/middlewares/context';
+import { setContext, setContextHono, setCorrelationId, setCorrelationIdHono, setTenantId, setTenantIdHono, setUserId, setUserIdHono } from '../../src/middlewares/context';
 
 // Mock dependencies
 vi.mock('../../src/core/hooks');
@@ -125,6 +125,27 @@ describe('Express Context Middleware', () => {
       }).toThrow('Tenant ID is required, but it is not present in the request headers');
     });
   });
+
+  describe('set user id', () => {
+    it('should use user ID from header', () => {
+      const testUserId = 'test-user';
+      mockRequest.headers = {
+        'x-user-id': testUserId
+      };
+
+      setUserId(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(hooks.setHookUserId).toHaveBeenCalledWith(testUserId);
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('should not set user ID if none provided in header', () => {
+      setUserId(mockRequest as Request, mockResponse as Response, mockNext);
+
+      expect(hooks.setHookUserId).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
 });
 
 describe('Hono Context Middleware', () => {
@@ -204,6 +225,28 @@ describe('Hono Context Middleware', () => {
       const middleware = setTenantIdHono();
       await expect(middleware(mockContext as Context, mockNext))
         .rejects.toThrow('Tenant ID is required, but it is not present in the request headers');
+    });
+  });
+
+  describe('setUserIdHono', () => {
+    it('should use user ID from header', async () => {
+      const testUserId = 'test-user';
+      (mockContext.req!.header as Mock).mockReturnValue(testUserId);
+
+      await setUserIdHono(mockContext as Context, mockNext);
+
+      expect(mockContext.req!.header).toHaveBeenCalledWith('x-user-id');
+      expect(hooks.setHookUserId).toHaveBeenCalledWith(testUserId);
+      expect(mockNext).toHaveBeenCalled();
+    });
+
+    it('should not set user ID if none provided in header', async () => {
+      (mockContext.req!.header as Mock).mockReturnValue(undefined);
+
+      await setUserIdHono(mockContext as Context, mockNext);
+
+      expect(hooks.setHookUserId).not.toHaveBeenCalled();
+      expect(mockNext).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
@
## O que

Adiciona o módulo de **audit / change history** ao framework: uma extension do Prisma que intercepta escritas em models configurados e grava um evento de auditoria (outbox) **de forma atômica**, no mesmo commit da escrita de negócio.

## Como está organizado (bottom-up)

- **Fundações** — `audit-context.ts` (contexto via `AsyncLocalStorage` que propaga a transação ativa) e `audit-actor.ts` (resolvers de actor/correlation a partir dos hooks de request).
- **Core** — `build-audit-event.ts` (contrato do evento, resolução do tipo de operação, diff raso, payload JSON-safe e campo de PK configurável), `registry.ts` e `run-in-transaction.ts` (`withTransaction` abre/junta a transação auditada).
- **Extension + API** — `create-audit-extension.ts` (intercepta writes e emite o outbox; resolve a tx via ALS, `$transaction` interativo raw ou auto-wrap; barra bulk/batch ops), barrel `index.ts` e `README.md`.
- **Empacotamento** — `@prisma/client` movido para `peerDependencies` (`>=6.3.1`) para resolver o client gerado do consumidor; novo subpath export `./audit` + `typesVersions`.

## Configuração de PK (`resourceId`)

Por padrão o `resourceId` vem do campo `id`. Models com PK diferente podem informar `idField` na regra; se o campo não existir, o `resourceId` sai vazio e um `warn` é logado (em vez da string literal `"undefined"`).

## Notas

- Inclui também o commit pré-existente do middleware `setUserId` (x-user-id), já presente no branch.
- Build e lint passando (`pnpm build`, `pnpm lint`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@